### PR TITLE
fix: exclude undici from client-side bundling to resolve webpack error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,13 +2,10 @@
 const nextConfig = {
   experimental: { appDir: true },
   reactStrictMode: true,
-  transpilePackages: ['undici'],
   webpack: (config, { isServer }) => {
+    // Exclude undici from client-side bundling
     if (!isServer) {
-      config.resolve.fallback = {
-        ...config.resolve.fallback,
-        undici: false,
-      };
+      config.externals = [...(config.externals || []), 'undici'];
     }
     return config;
   },


### PR DESCRIPTION
- Configure webpack to exclude undici from client-side builds
- Prevent webpack from processing undici's private class field syntax
- Fixes Module parse failed: Unexpected token error